### PR TITLE
Normalize \\ paths to / on windows based systems. Makes all tests pass

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const getPackages = require('get-monorepo-packages');
-const { dirname, relative, sep, resolve, isAbsolute } = require('path');
+const { dirname, join, relative, sep, normalize, isAbsolute } = require('path');
 
 const isSubPath = (parent, path) => {
   const relativePath = relative(parent, path);
@@ -23,7 +23,7 @@ const packages = getPackages(process.cwd()).map(
 const resolvePath = (parent, path) => {
   if (path[0] !== '.') return path;
 
-  return resolve(parent, path);
+  return join(parent, path).replace(/\\/g, '/');
 };
 
 const resolveImport = (context, node, { value, range }, currentPackage) => {
@@ -34,6 +34,8 @@ const resolveImport = (context, node, { value, range }, currentPackage) => {
 
 const pathToImport = path => {
   if (path === '') return '.';
+
+  path = normalize(path).replace(/\\/g, '/');
 
   if (path[0] !== '.') return `./${path}`;
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,11 +35,11 @@ const resolveImport = (context, node, { value, range }, currentPackage) => {
 const pathToImport = path => {
   if (path === '') return '.';
 
-  path = normalize(path).replace(/\\/g, '/');
+  const normalized = normalize(path).replace(/\\/g, '/');
 
-  if (path[0] !== '.') return `./${path}`;
+  if (normalized[0] !== '.') return `./${normalized}`;
 
-  return path;
+  return normalized;
 };
 
 const findCurrentPackage = context =>


### PR DESCRIPTION
Fixes github https://github.com/joshuajaco/eslint-plugin-workspaces/issues/1

NodeJS resolve returns \\  for paths in windows based systems and / for posix. This PR fixes the failed tests in this repository when running on windows.

This is the problem:
```
path.join('foo', '..', 'bar', 'baz/foo');
// 'bar/baz/foo' on OSX and Linux
// 'bar\\baz\\foo' on Windows
```

```
path.resolve('../', '/../', '../')
// '/home' on Linux
// '/Users' on OSX
// 'C:\\Users' on Windows
``` 

See https://shapeshed.com/writing-cross-platform-node/