### PR TITLE
Fix urls in problem messages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,7 @@ module.exports = {
       'error',
       {
         pattern:
-          'https://github.com/joshuajaco/eslint-plugin-workspaces/docs/rules/{{name}}.md',
+          'https://github.com/joshuajaco/eslint-plugin-workspaces/blob/master/docs/rules/{{name}}.md',
       },
     ],
     'prettier/prettier': 'error',

--- a/lib/rules/no-absolute-imports.js
+++ b/lib/rules/no-absolute-imports.js
@@ -9,7 +9,7 @@ module.exports.meta = {
     description:
       'disallow absolute imports for files that are within the current package',
     url:
-      'https://github.com/joshuajaco/eslint-plugin-workspaces/docs/rules/no-absolute-imports.md',
+      'https://github.com/joshuajaco/eslint-plugin-workspaces/blob/master/docs/rules/no-absolute-imports.md',
   },
   fixable: 'code',
   schema: [],

--- a/lib/rules/no-cross-imports.js
+++ b/lib/rules/no-cross-imports.js
@@ -7,7 +7,7 @@ module.exports.meta = {
   docs: {
     description: 'disallow imports of files that are inside another package',
     url:
-      'https://github.com/joshuajaco/eslint-plugin-workspaces/docs/rules/no-cross-imports.md',
+      'https://github.com/joshuajaco/eslint-plugin-workspaces/blob/master/docs/rules/no-cross-imports.md',
   },
   schema: [
     {

--- a/lib/rules/no-relative-imports.js
+++ b/lib/rules/no-relative-imports.js
@@ -8,7 +8,7 @@ module.exports.meta = {
     description:
       'disallow relative imports of files that are outside of the current package',
     url:
-      'https://github.com/joshuajaco/eslint-plugin-workspaces/docs/rules/no-relative-imports.md',
+      'https://github.com/joshuajaco/eslint-plugin-workspaces/blob/master/docs/rules/no-relative-imports.md',
   },
   fixable: 'code',
   schema: [],

--- a/lib/rules/require-dependency.js
+++ b/lib/rules/require-dependency.js
@@ -8,7 +8,7 @@ module.exports.meta = {
     description:
       'disallow importing from packages that are not listed as a dependency',
     url:
-      'https://github.com/joshuajaco/eslint-plugin-workspaces/docs/rules/require-dependency.md',
+      'https://github.com/joshuajaco/eslint-plugin-workspaces/blob/master/docs/rules/require-dependency.md',
   },
   schema: [],
 };


### PR DESCRIPTION
The linter wants it removed, but the url without `blob/master` results in `404`.