### PR TITLE
Enable scoped sharing of workspaces

### DIFF
--- a/docs/rules/no-cross-imports.md
+++ b/docs/rules/no-cross-imports.md
@@ -8,7 +8,7 @@ This rule takes one argument:
 
 ```
 ...
-"workspaces/no-cross-imports": ["error", { allow: ["@project/A", "@project/B"] }]
+"workspaces/no-cross-imports": ["error", { allow: ["@project/A", "@project/B"], scopes: { enable: true, folderName: 'shared' } }]
 ...
 ```
 
@@ -16,7 +16,7 @@ This rule takes one argument:
 
 Takes a single or a list of package names to exclude from this rule.
 
-## Example
+#### Example
 
 These examples have the following project structure:
 
@@ -45,4 +45,92 @@ import bar from '../B/bar';
 
 // inside "project/index.js"
 import foo from './packages/B/foo';
+```
+
+### scopes
+
+Takes either a boolean or an options object. Defaults to `false`.
+
+Scopes are a way to partially allow imports across workspace boundaries.
+In larger monorepos, you might run into a situation where you want to group code
+across _some_ packages, but not all of them. A natural way to do this would be
+to create folder structure that visualizes this. So your structure might look
+like this:
+
+```
+project
+└─── packages
+     └─── shared-components/
+          └─── package.json
+     └─── welcome-page/
+          └─── package.json
+     └─── user-management/
+          └─── registration/
+               └─── package.json
+          └─── login/
+               └─── package.json
+```
+                                                                         
+Now, we may want to share code across the packages in the `user-management`
+section (e.g. fetching the user object, user form components etc.). With scopes,
+i am always allowed to import from a package with a **special folder name**
+(see below) given that it shares a common folder parent. So for
+the above case, I would be able to do this:
+
+```
+project
+└─── packages
+     └─── shared-components/
+          └─── package.json
+     └─── welcome-page/
+          └─── package.json
+     └─── user-management/
+          └─── shared/
+               └─── package.json
+          └─── registration/
+               └─── package.json
+          └─── login/
+               └─── package.json
+```
+
+When passing a boolean, the default folder name `shared` will be used. If you
+want to configure this, pass another string via the `folderName` key.
+
+#### Example
+
+These examples have the following project structure:
+
+```
+project
+└─── packages
+     └─── shared-components/
+          └─── package.json
+     └─── welcome-page/
+          └─── package.json
+     └─── user-management/
+          └─── shared/
+               └─── package.json
+          └─── registration/
+               └─── package.json
+          └─── login/
+               └─── package.json
+```
+
+Examples of **incorrect** code for this rule:
+
+```js
+// inside "project/packages/welcome-page/index.js"
+// configuration: [{ allow: "@project/user-management-shared", scopes: true }]
+import foo from '@project/user-management-shared';
+```
+
+Examples of **correct** code for this rule:
+
+```js
+// inside "project/packages/user-management/registration/index.js"
+// configuration: [{ allow: "@project/user-management-shared", scopes: true }]
+import foo from '@project/user-management-shared';
+
+// inside "project/index.js"
+import foo from './packages/user-management/registration';
 ```

--- a/lib/rules/no-cross-imports.js
+++ b/lib/rules/no-cross-imports.js
@@ -26,34 +26,59 @@ module.exports.meta = {
             },
           ],
         },
+        scopes: {
+          anyOf: [
+            { type: 'boolean', additionalProperties: false },
+            {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                enable: { type: 'boolean' },
+                folderName: { type: 'string' },
+              },
+            },
+          ],
+        },
       },
     },
   ],
 };
 
-const filterSharedPackagesInCurrentScope = ({ location: currentLocation }) => ({
-  location,
-}) => {
+const filterSharedPackagesInCurrentScope = (
+  { location: currentLocation },
+  scopedEnabled,
+  scopedSharingFolderName,
+) => ({ location }) => {
+  if (!scopedEnabled) return true;
   const locationArray = location.split('/');
   const forbiddenPackageParent = locationArray.slice(0, -1).join('/');
   if (!isSubPath(forbiddenPackageParent, currentLocation)) {
     return true;
   }
 
-  return locationArray[locationArray.length - 1] !== 'shared';
+  return locationArray[locationArray.length - 1] !== scopedSharingFolderName;
 };
 
 module.exports.create = (context) => {
   const {
-    options: [{ allow = [] } = {}],
+    options: [{ allow = [], scopes = { enable: false } } = {}],
   } = context;
 
   const allowed = typeof allow === 'string' ? [allow] : allow;
+  const scopedEnabled = scopes === true || !!scopes.enable;
+  const scopedSharingFolderName = scopes.folderName || 'shared';
+
   const forbidden = packages.filter(({ name }) => !allowed.includes(name));
 
   return getImport(context, ({ node, value, path, currentPackage }) => {
     forbidden
-      .filter(filterSharedPackagesInCurrentScope(currentPackage))
+      .filter(
+        filterSharedPackagesInCurrentScope(
+          currentPackage,
+          scopedEnabled,
+          scopedSharingFolderName,
+        ),
+      )
       .forEach(({ name, location }) => {
         if (
           name !== currentPackage.name &&

--- a/lib/rules/no-cross-imports.js
+++ b/lib/rules/no-cross-imports.js
@@ -31,6 +31,18 @@ module.exports.meta = {
   ],
 };
 
+const filterSharedPackagesInCurrentScope = ({ location: currentLocation }) => ({
+  location,
+}) => {
+  const locationArray = location.split('/');
+  const forbiddenPackageParent = locationArray.slice(0, -1).join('/');
+  if (!isSubPath(forbiddenPackageParent, currentLocation)) {
+    return true;
+  }
+
+  return locationArray[locationArray.length - 1] !== 'shared';
+};
+
 module.exports.create = (context) => {
   const {
     options: [{ allow = [] } = {}],
@@ -40,17 +52,19 @@ module.exports.create = (context) => {
   const forbidden = packages.filter(({ name }) => !allowed.includes(name));
 
   return getImport(context, ({ node, value, path, currentPackage }) => {
-    forbidden.forEach(({ name, location }) => {
-      if (
-        name !== currentPackage.name &&
-        (isSubPath(name, value) || isSubPath(location, path))
-      ) {
-        context.report({
-          node,
-          message: 'Import from package "{{name}}" is not allowed',
-          data: { name },
-        });
-      }
-    });
+    forbidden
+      .filter(filterSharedPackagesInCurrentScope(currentPackage))
+      .forEach(({ name, location }) => {
+        if (
+          name !== currentPackage.name &&
+          (isSubPath(name, value) || isSubPath(location, path))
+        ) {
+          context.report({
+            node,
+            message: 'Import from package "{{name}}" is not allowed',
+            data: { name },
+          });
+        }
+      });
   });
 };

--- a/tests/rules/no-cross-imports.js
+++ b/tests/rules/no-cross-imports.js
@@ -38,6 +38,10 @@ ruleTester.run('no-cross-imports', rule, {
       filename: '/some/file.js',
       code: "import '@test/workspace';",
     },
+    {
+      filename: '/test/scope/workspace/file.js',
+      code: "import '@test/shared-in-scope';",
+    },
   ],
 
   invalid: [
@@ -181,6 +185,16 @@ ruleTester.run('no-cross-imports', rule, {
         {
           message:
             'Import from package "@test/another-workspace" is not allowed',
+        },
+      ],
+    },
+    {
+      filename: '/test/scope/workspace/file.js',
+      code: "import '@test/shared-outside-scope';",
+      errors: [
+        {
+          message:
+            'Import from package "@test/shared-outside-scope" is not allowed',
         },
       ],
     },

--- a/tests/rules/no-cross-imports.js
+++ b/tests/rules/no-cross-imports.js
@@ -39,6 +39,17 @@ ruleTester.run('no-cross-imports', rule, {
       code: "import '@test/workspace';",
     },
     {
+      options: [{ scopes: true }],
+      filename: '/test/scope/workspace/file.js',
+      code: "import '@test/shared-in-scope';",
+    },
+    {
+      options: [{ scopes: { enable: true } }],
+      filename: '/test/scope/workspace/file.js',
+      code: "import '@test/shared-in-scope';",
+    },
+    {
+      options: [{ scopes: { enable: true, folderName: 'shared' } }],
       filename: '/test/scope/workspace/file.js',
       code: "import '@test/shared-in-scope';",
     },
@@ -189,12 +200,32 @@ ruleTester.run('no-cross-imports', rule, {
       ],
     },
     {
+      options: [{ scopes: true }],
       filename: '/test/scope/workspace/file.js',
       code: "import '@test/shared-outside-scope';",
       errors: [
         {
           message:
             'Import from package "@test/shared-outside-scope" is not allowed',
+        },
+      ],
+    },
+    {
+      filename: '/test/scope/workspace/file.js',
+      code: "import '@test/shared-in-scope';",
+      errors: [
+        {
+          message: 'Import from package "@test/shared-in-scope" is not allowed',
+        },
+      ],
+    },
+    {
+      options: [{ scopes: { enable: true, folderName: 'something-else' } }],
+      filename: '/test/scope/workspace/file.js',
+      code: "import '@test/shared-in-scope';",
+      errors: [
+        {
+          message: 'Import from package "@test/shared-in-scope" is not allowed',
         },
       ],
     },

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -22,4 +22,22 @@ mock('get-monorepo-packages', () => [
       name: '@test/third-workspace',
     },
   },
+  {
+    location: '/test/scope/shared',
+    package: {
+      name: '@test/shared-in-scope',
+    },
+  },
+  {
+    location: '/test/other-scope/shared',
+    package: {
+      name: '@test/shared-outside-scope',
+    },
+  },
+  {
+    location: '/test/scope/workspace',
+    package: {
+      name: '@test/scoped-workspace',
+    },
+  },
 ]);


### PR DESCRIPTION
In larger monorepos, you might run into a situation where you want to group code across _some_ packages, but not all of them. A natural way to do this would be to create folder structure that visualizes this. So your structure might look like this:
```
- packages
- - shared-components/
- - - package.json
- - welcome-page/
- - - package.json
- - user-management/
- - - registration/
- - - - package.json
- - - login/
- - - - package.json
```

Now, we may want to share code across the packages in the `user-management` section (e.g. fetching the user object, user form components etc.). Currently, the plugin only allows to share something across all packages or not at all. This PR introduces the concept of sharing within a "scope" (i.e.) folder. So for the above case, i would be able to do this:
```
- packages
- - shared-components/
- - - package.json
- - welcome-page/
- - - package.json
- - user-management/
- - - shared/
- - - - package.json
- - - registration/
- - - - package.json
- - - login/
- - - - package.json
```

from the `registration` and `login` package, importing from the package in `shared` would be allowed because:
a) scoped sharing is enabled in the settings
a) they share a common parent folder (in this case `user-management`)
b) the folder name of the workspace we're importing from is `shared` (configurable in the settings)