### PR TITLE
Add support for lerna-based eslint runs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@
 module.exports = {
   env: {
     node: 1,
+    mocha: 1,
   },
   parserOptions: {
     ecmaVersion: 2020,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,7 +32,7 @@ const directoryContainsRootPackageJson = (path) => {
 
 const getRepositoryRoot = (path = process.cwd()) => {
   let pathForCheck = path;
-  while (pathForCheck !== '/') {
+  while (pathForCheck !== resolve(pathForCheck, '..')) {
     if (directoryContainsRootPackageJson(pathForCheck)) {
       return pathForCheck;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,14 +1,49 @@
 'use strict';
 
 const getPackages = require('get-monorepo-packages');
-const { dirname, join, relative, sep, normalize, isAbsolute } = require('path');
+const fs = require('fs');
+const {
+  dirname,
+  join,
+  relative,
+  sep,
+  normalize,
+  isAbsolute,
+  resolve,
+} = require('path');
 
 const isSubPath = (parent, path) => {
   const relativePath = relative(parent, path);
   return relativePath.split(sep)[0] !== '..' && !isAbsolute(relativePath);
 };
 
-const packages = getPackages(process.cwd()).map(
+const directoryContainsRootPackageJson = (path) => {
+  try {
+    const pathToCheck = resolve(path, 'package.json');
+    if (!fs.existsSync(pathToCheck)) return false;
+    const pkg = require(pathToCheck);
+    if (pkg && {}.hasOwnProperty.call(pkg, 'workspaces')) {
+      return true;
+    }
+  } catch (e) {
+    return false;
+  }
+};
+
+const getRepositoryRoot = (path = process.cwd()) => {
+  let pathForCheck = path;
+  while (pathForCheck !== '/') {
+    if (directoryContainsRootPackageJson(pathForCheck)) {
+      return pathForCheck;
+    }
+
+    pathForCheck = resolve(pathForCheck, '..');
+  }
+
+  return path;
+};
+
+const packages = getPackages(getRepositoryRoot()).map(
   ({
     package: { name, dependencies = {}, devDependencies = {} },
     location,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -109,4 +109,10 @@ const getImport = (context, callback) => {
   };
 };
 
-module.exports = { isSubPath, packages, getImport, pathToImport };
+module.exports = {
+  isSubPath,
+  packages,
+  getImport,
+  pathToImport,
+  getRepositoryRoot,
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,16 +18,13 @@ const isSubPath = (parent, path) => {
 };
 
 const directoryContainsRootPackageJson = (path) => {
-  try {
-    const pathToCheck = resolve(path, 'package.json');
-    if (!fs.existsSync(pathToCheck)) return false;
-    const pkg = require(pathToCheck);
-    if (pkg && {}.hasOwnProperty.call(pkg, 'workspaces')) {
-      return true;
-    }
-  } catch (e) {
-    return false;
+  const pathToCheck = resolve(path, 'package.json');
+  if (!fs.existsSync(pathToCheck)) return false;
+  const pkg = require(pathToCheck);
+  if (pkg && {}.hasOwnProperty.call(pkg, 'workspaces')) {
+    return true;
   }
+  return false;
 };
 
 const getRepositoryRoot = (path = process.cwd()) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,12 +29,17 @@ const directoryContainsRootPackageJson = (path) => {
 
 const getRepositoryRoot = (path = process.cwd()) => {
   let pathForCheck = path;
+
+  if (directoryContainsRootPackageJson(pathForCheck)) {
+    return pathForCheck;
+  }
+
   while (pathForCheck !== resolve(pathForCheck, '..')) {
+    pathForCheck = resolve(pathForCheck, '..');
+
     if (directoryContainsRootPackageJson(pathForCheck)) {
       return pathForCheck;
     }
-
-    pathForCheck = resolve(pathForCheck, '..');
   }
 
   return path;

--- a/tests/utils/getRepositoryRoot.js
+++ b/tests/utils/getRepositoryRoot.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const path = require('path');
 
 describe('getRepositoryRoot', () => {
-  it('should detect root path in monorepository', () => {
+  it('should detect root path from package in monorepository', () => {
     const pkgPath = path.resolve(
       __dirname,
       './mocks/repo-with-workspaces/package/',
@@ -15,5 +15,15 @@ describe('getRepositoryRoot', () => {
     const utils = require('../../lib/utils');
 
     assert.ok(utils.getRepositoryRoot() === path.resolve(pkgPath, '..'));
+  });
+
+  it('should detect root path from root in monorepository', () => {
+    const pkgPath = path.resolve(__dirname, './mocks/repo-with-workspaces/');
+
+    process.chdir(pkgPath);
+
+    const utils = require('../../lib/utils');
+
+    assert.ok(utils.getRepositoryRoot() === pkgPath);
   });
 });

--- a/tests/utils/getRepositoryRoot.js
+++ b/tests/utils/getRepositoryRoot.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+
+describe('getRepositoryRoot', () => {
+  it('should detect root path in monorepository', () => {
+    const pkgPath = path.resolve(
+      __dirname,
+      './mocks/repo-with-workspaces/package/',
+    );
+
+    process.chdir(pkgPath);
+
+    const utils = require('../../lib/utils');
+
+    assert.ok(utils.getRepositoryRoot() === path.resolve(pkgPath, '..'));
+  });
+});

--- a/tests/utils/mocks/repo-with-workspaces/package.json
+++ b/tests/utils/mocks/repo-with-workspaces/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "workspaces": ["./"]
+}


### PR DESCRIPTION
Hi! 

In our monorepository we use lerna for running eslint parallel

Like this:
```
    "lint": "lerna run lint --parallel --no-bail",
```

In this case `process.cwd()` return not repo-root path, but package path.

In my solution I search repo-root by searching package.json with `workspaces` property
