### PR TITLE
Fix path normalization for windows

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,15 @@
 "use strict";
 
-const { dirname, join, relative, sep, normalize, isAbsolute } = require("path");
-const { findWorkspaces } = require("find-workspaces");
+const {
+  dirname,
+  join,
+  relative,
+  sep,
+  normalize,
+  isAbsolute,
+  posix,
+} = require("path");
+const { findWorkspaces, createWorkspacesCache } = require("find-workspaces");
 
 const isSubPath = (parent, path) => {
   const relativePath = relative(parent, path);
@@ -11,7 +19,7 @@ const isSubPath = (parent, path) => {
 const resolvePath = (parent, path) => {
   if (path[0] !== ".") return path;
 
-  return join(parent, path).replace(/\\/g, "/");
+  return join(parent, path).split(sep).join(posix.sep);
 };
 
 const resolveImport = (filename, node, { value, range }, currentWorkspace) => {
@@ -23,7 +31,7 @@ const resolveImport = (filename, node, { value, range }, currentWorkspace) => {
 const pathToImport = (path) => {
   if (path === "") return ".";
 
-  const normalized = normalize(path).replace(/\\/g, "/");
+  const normalized = normalize(path).split(sep).join(posix.sep);
 
   if (normalized[0] !== ".") return `./${normalized}`;
 
@@ -63,6 +71,8 @@ const getImport = (workspaces, filename, callback) => {
   };
 };
 
+const cache = createWorkspacesCache();
+
 const getWorkspaces = (context) => {
   const searchSetting =
     context.settings &&
@@ -75,7 +85,7 @@ const getWorkspaces = (context) => {
 
   const stopDir = searchSetting && searchSetting.stopDir;
 
-  return findWorkspaces(dir, { stopDir });
+  return findWorkspaces(dir, { stopDir, cache });
 };
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.0-rc2",
       "license": "MIT",
       "dependencies": {
-        "find-workspaces": "^0.0.2"
+        "find-workspaces": "^0.0.4"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.3",
@@ -1560,9 +1560,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -1571,7 +1571,7 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
@@ -1662,11 +1662,11 @@
       }
     },
     "node_modules/find-workspaces": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/find-workspaces/-/find-workspaces-0.0.2.tgz",
-      "integrity": "sha512-uutNYiYVKxZ4NMbShlWUyLs74WZ3zqX+Yat+3jjB19AEwfm88C/1AfuQZWWUz8WhlGZy5oBlOacQEbPp7alJ6g==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/find-workspaces/-/find-workspaces-0.0.4.tgz",
+      "integrity": "sha512-h1stMSiZixD+BNTB6oHZoZAv6Nw92wB9uQEbVJ+24Ee/+ZhkP6++/9cQgG+wo6a07GvnzmqesQ6voiqfEJylCw==",
       "dependencies": {
-        "globby": "^11.0.4"
+        "globby": "^11.1.0"
       },
       "engines": {
         "node": ">= 12.22.0"
@@ -1834,15 +1834,15 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1853,9 +1853,9 @@
       }
     },
     "node_modules/globby/node_modules/ignore": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "engines": {
         "node": ">= 4"
       }
@@ -2462,12 +2462,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -3011,9 +3011,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -4935,9 +4935,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -5015,11 +5015,11 @@
       }
     },
     "find-workspaces": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/find-workspaces/-/find-workspaces-0.0.2.tgz",
-      "integrity": "sha512-uutNYiYVKxZ4NMbShlWUyLs74WZ3zqX+Yat+3jjB19AEwfm88C/1AfuQZWWUz8WhlGZy5oBlOacQEbPp7alJ6g==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/find-workspaces/-/find-workspaces-0.0.4.tgz",
+      "integrity": "sha512-h1stMSiZixD+BNTB6oHZoZAv6Nw92wB9uQEbVJ+24Ee/+ZhkP6++/9cQgG+wo6a07GvnzmqesQ6voiqfEJylCw==",
       "requires": {
-        "globby": "^11.0.4"
+        "globby": "^11.1.0"
       }
     },
     "flat": {
@@ -5133,22 +5133,22 @@
       "dev": true
     },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "dependencies": {
         "ignore": {
-          "version": "5.1.9",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-          "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
         }
       }
     },
@@ -5598,12 +5598,12 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "minimatch": {
@@ -6028,9 +6028,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pkg-dir": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "coverage": "mkdir -p coverage && touch ./coverage/lcov.info && nyc report --reporter=text-lcov > ./coverage/lcov.info"
   },
   "dependencies": {
-    "find-workspaces": "^0.0.2"
+    "find-workspaces": "^0.0.4"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.16.3",


### PR DESCRIPTION
Hello, I tested the plugin on my windows machine. Using both `cmd` or `MINGW` I go the same result:
```ts
// Before
import { APIKeySecurityScheme } from "../../td-tools/src/thing-description";
// After
import { APIKeySecurityScheme } from "C:/Users/username/internal/node-wot/packages/td-tools/src/thing-description";
```

After debugging I noticed that in https://github.com/joshuajaco/eslint-plugin-workspaces/blob/042f3ef4a0700e3a5c154976791aa30643851dfb/lib/rules/no-relative-imports.js#L34-L38

path equals: `C:/Users/username/internal/node-wot/packages/td-tools/src/thing-description`
location equals: `C:\Users\username\internal\node-wot\packages\td-tools`

At first glance it seems that the two paths were "normalized" differently, hence I made this PR to treat them the same. Plus I also changed the test to reflect closely a real environment. I noticed that find-workspace is using `path.resolve`, therefore I've updated the tests accordingly. Notice that I only focused on failing tests for no-relative-imports, let me know if I have to extend the usage of `path.resolve` also to other tests. 
