### PR TITLE
feat(require-dependency): `peerDependencies` & `optionalDependencies`

### DIFF
--- a/lib/rules/require-dependency.js
+++ b/lib/rules/require-dependency.js
@@ -23,13 +23,19 @@ module.exports.create = (context) => {
     context.getFilename(),
     ({ node, value, path, currentWorkspace }) => {
       workspaces.forEach(({ package: { name }, location }) => {
-        const { dependencies = {}, devDependencies = {} } =
-          currentWorkspace.package;
+        const {
+          dependencies = {},
+          peerDependencies = {},
+          optionalDependencies = {},
+          devDependencies = {},
+        } = currentWorkspace.package;
 
         if (
           name !== currentWorkspace.package.name &&
           (isSubPath(name, value) || isSubPath(location, path)) &&
           !Object.keys(dependencies).includes(name) &&
+          !Object.keys(peerDependencies).includes(name) &&
+          !Object.keys(optionalDependencies).includes(name) &&
           !Object.keys(devDependencies).includes(name)
         ) {
           context.report({

--- a/tests/mocks.js
+++ b/tests/mocks.js
@@ -21,6 +21,20 @@ module.exports.findWorkspacesMock = () => [
     },
   },
   {
+    location: "/test/peer-dependencies",
+    package: {
+      name: "@test/peer-dependencies",
+      peerDependencies: { "@test/peer-workspace": "^1.0.0" },
+    },
+  },
+  {
+    location: "/test/optional-dependencies",
+    package: {
+      name: "@test/optional-dependencies",
+      optionalDependencies: { "@test/optional-workspace": "^1.0.0" },
+    },
+  },
+  {
     location: "/test/scope/shared",
     package: {
       name: "@test/shared-in-scope",

--- a/tests/rules/require-dependency.js
+++ b/tests/rules/require-dependency.js
@@ -22,6 +22,14 @@ describe("require-dependency", () => {
         filename: "/test/workspace/test.js",
         code: "require(undefined)",
       },
+      {
+        filename: "/test/peer-dependencies/test.js",
+        code: "import '@test/peer-workspace'",
+      },
+      {
+        filename: "/test/optional-dependencies/test.js",
+        code: "import '@test/optional-workspace'",
+      },
     ],
     invalid: [
       {


### PR DESCRIPTION
Now `peerDependencies` and `optionalDependencies` are also considered in the `require-dependency` rule.